### PR TITLE
Use `get!` instead of `get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ of which
 - `https://username@password.heroku.cloudant.com` is the URL of the CouchDB instance
 - `backups` is the name of the CouchDB database. The database will be automatically created if it doesn't exist.
 - `weekly` it the name of the document to write the timestamps to. The document is created if it doesn't exist.
+
+## Development
+
+Install the dependencies with `bundle install`, and run the tests with `bundle exec rake`.

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,9 @@
 require "bundler/gem_tasks"
 require 'rake/testtask'
 
- Rake::TestTask.new do |t|
-   t.libs.push "spec"
-   t.test_files = FileList['spec/**/*_spec.rb']
- end
+Rake::TestTask.new(:test) do |t|
+  t.libs.push "spec"
+  t.test_files = FileList['spec/**/*_spec.rb']
+end
+
+task :default => :test

--- a/im-alive.gemspec
+++ b/im-alive.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "minitest", "~> 5.5"
   spec.add_development_dependency "timecop"
+  spec.add_development_dependency "rake"
 
   spec.add_runtime_dependency "couchrest", ["~> 2.0.0.rc2"]
 end

--- a/lib/im_alive/log.rb
+++ b/lib/im_alive/log.rb
@@ -9,7 +9,7 @@ module ImAlive
 
     def send
       doc = begin
-        db.get(document_id)
+        db.get!(document_id)
       rescue CouchRest::NotFound
         {'_id' => document_id}
       end

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -9,7 +9,7 @@ module ImAlive
 
       Timecop.freeze Time.utc(2015, 02, 1, 0, 0, 0) do
         logger.stub :db, rest_client do
-          rest_client.expect :get, {}, ['polly']
+          rest_client.expect :get!, {}, ['polly']
           rest_client.expect :save_doc, {}, [{"timestamp" => "2015-02-01 00:00:00 UTC", "js_timestamp" => 1422748800}]
 
           logger.send

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
 require 'im_alive'
 require 'minitest/autorun'
-require 'minitest/pride'
 require 'timecop'


### PR DESCRIPTION
`get` will never raise the `CouchRest::NotFound` exception that we are catching to handle the cases where the requested document does no exist. By using the bang version of this method we should have the expected behaviour: Find or create a document.

Reference: https://github.com/couchrest/couchrest/blob/cdd3ad30b9fa9aad5464cb4647c18c198b2c48d9/lib/couchrest/database.rb#L95-L115